### PR TITLE
Add recent transactions table to Home

### DIFF
--- a/frontend/Controls/BoardHeader.qml
+++ b/frontend/Controls/BoardHeader.qml
@@ -4,6 +4,7 @@ Item {
     readonly property color cHeaderText: "#e2e2e2"
     readonly property color cHeaderLine: "#535353"
 
+    property alias menuLabelText: menuLabel.text
     property alias text: label.text
 
     height: 44.5
@@ -41,7 +42,7 @@ Item {
         }
 
         Text {
-            text: qsTr("XBY")
+            id: menuLabel
             color: cHeaderText
             font.family: "Roboto"
             font.pixelSize: 12

--- a/frontend/X-Board/Home/BalanceBoard.qml
+++ b/frontend/X-Board/Home/BalanceBoard.qml
@@ -7,13 +7,14 @@ import "../../Controls" as Controls
 Rectangle {
     width: 376
     height: 313
-    color: "#3a3e46"
+    color: cBoardBackground
     radius: 5
     Layout.minimumHeight: 313
     Layout.fillHeight: true
 
     Controls.BoardHeader {
         text: qsTr("BALANCE")
+        menuLabelText: qsTr("XBY")
     }
 
     Controls.BalanceItem {

--- a/frontend/X-Board/Home/BalanceValueBoard.qml
+++ b/frontend/X-Board/Home/BalanceValueBoard.qml
@@ -6,18 +6,19 @@ import "../../Controls" as Controls
 Rectangle {
     width: 376
     height: 135
-    color: "#3a3e46"
+    color: cBoardBackground
     radius: 5
 
     Controls.BoardHeader {
         id: boardHeader
         text: qsTr("BALANCE VALUE")
+        menuLabelText: qsTr("USD")
     }
 
     Controls.BalanceItem {
         id: unconfirmedBalance
         text: ""
-        value: "5,446"
+        value: "37,621"
         valuePrefix: qsTr("$")
         anchors.top: boardHeader.bottom
     }

--- a/frontend/X-Board/Home/Layout.qml
+++ b/frontend/X-Board/Home/Layout.qml
@@ -2,6 +2,8 @@ import QtQuick 2.0
 import QtQuick.Layouts 1.3
 
 ColumnLayout {
+    readonly property color cBoardBackground: "#3a3e46"
+
     id: xBoardHome
     anchors.left: parent.left
     anchors.right: parent.right
@@ -20,13 +22,7 @@ ColumnLayout {
             }
         }
 
-        Rectangle {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.minimumHeight: 200
-            Layout.preferredHeight: 400
-            color: "#3A3E47"
-            radius: 5
+        RecentTransactionsBoard {
         }
     }
 

--- a/frontend/X-Board/Home/RecentTransactionsBoard.qml
+++ b/frontend/X-Board/Home/RecentTransactionsBoard.qml
@@ -1,0 +1,308 @@
+import QtQuick 2.0
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
+import SortFilterProxyModel 0.1
+import QtQuick.Dialogs 1.1
+
+import "../../Controls" as Controls
+
+Rectangle {
+    color: cBoardBackground
+    radius: 5
+    Layout.minimumHeight: 465
+    Layout.minimumWidth: 928.26
+    Layout.fillHeight: true
+    Layout.fillWidth: true
+
+    Controls.BoardHeader {
+        id: boardHeader
+        text: qsTr("RECENT TRANSACTIONS")
+        menuLabelText: qsTr("Complete View")
+    }
+
+    // TODO: This will be replaced by a bespoke dialog
+    MessageDialog {
+        id: popup
+        title: "Test"
+        text: "Item clicked"
+    }
+
+    TableView {
+        id: transactionTable
+
+        model: SortFilterProxyModel {
+            id: proxyModel
+            source: transactionModel.count > 0 ? transactionModel : null
+            sortOrder: transactionTable.sortIndicatorOrder
+            sortCaseSensitivity: Qt.CaseInsensitive
+            sortRole: transactionModel.count > 0 ? transactionTable.getColumn(transactionTable.sortIndicatorColumn).role : ""
+        }
+
+        // TODO: This is just a placeholder to test out click-to-view a transaction
+        onDoubleClicked: {
+            popup.open();
+        }
+
+        backgroundVisible: false
+        alternatingRowColors: false
+        frameVisible: false
+
+        anchors.top: boardHeader.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 15
+        anchors.leftMargin: 22
+
+        style: TableViewStyle {
+            scrollBarBackground: Item {
+                implicitWidth: 14
+                implicitHeight: 16
+            }
+
+            // Scrollbar specific properties
+            transientScrollBars: true   // We use this because the default scrollbars look awful
+            handle: Item {
+                implicitWidth: 14
+                implicitHeight: 16
+
+                Rectangle {
+                    color: "#0ED8D2"
+                    opacity: 0.6
+                    anchors.fill: parent
+                    anchors.leftMargin: 5
+                    radius: 4
+                    anchors.rightMargin: 1
+                }
+            }
+
+            // Table header attributes
+            headerDelegate: Rectangle {
+                height: 55
+                color: "#3A3E46"    // This needs to be set (non to avoid the rows being visible under the header
+
+                Text {
+                    color: "#FFF7F7"
+                    verticalAlignment: Text.AlignVCenter
+                    height: parent.height
+                    text: styleData.value
+                    font.pixelSize: 16
+                    font.family: "Roboto"
+                    font.weight: Font.Light
+
+                    Rectangle {
+                        anchors.top: parent.verticalCenter
+                        anchors.topMargin: 20
+                        width: parent.width ? 60 : 0    // Avoid extraneous underline after last column
+                        height: 1
+                        color: "#24B9C3"
+                    }
+                }
+            }
+
+            // Table row attributes
+            rowDelegate: Rectangle {
+                color: "transparent"
+                height: 60
+
+                Rectangle {
+                    height: 1
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.bottom
+                    anchors.leftMargin: 10
+                    color: "#535353"
+                }
+            }
+
+            // Table item attributes
+            itemDelegate: Item {
+                Text {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.rightMargin: 26
+
+                    color: {
+                        switch (styleData.column) {
+                        case 1:
+                        case 6:
+                            // Colour columns 1 and 6 (Type and value) based on the hidden type column. Keeps things language agnostic
+                            var row = transactionModel.get(styleData.row);
+                            row && row.type === "IN" ? "#0ED8D2" : "#F77E7E"
+                            break;
+                        default:
+                            "#ffffff"
+                            break;
+                        }
+                    }
+
+                    text: {
+                        switch (styleData.column) {
+                        case 6:
+                            // Add the + prefix and XBY suffix to column 6 (value)
+                            (styleData.value > 0 ? ("+" + styleData.value) : styleData.value) + " XBY";
+                            break;
+                        default:
+                            styleData.value;
+                        }
+                    }
+
+                    // Ensure ellipsis are applied
+                    elide: styleData.elideMode
+                    width: parent.width
+
+                    font.pixelSize: 12
+                    font.family: "Roboto"
+                }
+            }
+        }
+
+        // Hidden column used to determine which colors should be applied.
+        // TODO: Do we want columns to be resizable?
+        TableViewColumn {
+            title: "type"
+            role: "type"
+            visible: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Type")
+            role: "typeLabel"
+            width: 125
+            resizable: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Date")
+            role: "date"
+            width: 150
+            resizable: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Time")
+            role: "time"
+            width: 100
+            resizable: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Address")
+            role: "address"
+            width: 175
+            resizable: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Transaction ID")
+            role: "transactionID"
+            width: 175
+            resizable: false
+        }
+
+        TableViewColumn {
+            title: qsTr("Value")
+            role: "value"
+            width: 125
+            resizable: false
+        }
+
+        ListModel {
+            id: transactionModel
+
+            // Placeholder data
+            ListElement {
+                type: "IN"
+                typeLabel: qsTr("Received")
+                date: "Monday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: 1000000
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Tuesday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -5000
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Wednesday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -6000
+            }
+            ListElement {
+                type: "IN"
+                typeLabel: qsTr("Received")
+                date: "Thursday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: 15000
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Friday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -19000
+            }
+            ListElement {
+                type: "IN"
+                typeLabel: qsTr("Received")
+                date: "Saturday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: 8000
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Sunday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -8005
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Monday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -1234.45
+            }
+            ListElement {
+                type: "IN"
+                typeLabel: qsTr("Received")
+                date: "Tuesday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: 2345.34
+            }
+            ListElement {
+                type: "OUT"
+                typeLabel: qsTr("Sent")
+                date: "Wednesday, 24th of January"
+                time: "12:45PM"
+                address: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                transactionID: "xghl32lk8dfss577g734j34xghl32lk8dfss577g734j34"
+                value: -1234.45
+            }
+        }
+    }
+}

--- a/frontend/frontend.qrc
+++ b/frontend/frontend.qrc
@@ -32,5 +32,6 @@
         <file>X-Board/Home/BalanceBoard.qml</file>
         <file>X-Board/Home/BalanceValueBoard.qml</file>
         <file>X-Board/Home/Layout.qml</file>
+        <file>X-Board/Home/RecentTransactionsBoard.qml</file>
     </qresource>
 </RCC>

--- a/frontend/support/sortfilterproxymodel.cpp
+++ b/frontend/support/sortfilterproxymodel.cpp
@@ -1,0 +1,168 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** You may use this file under the terms of the BSD license as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of Digia Plc and its Subsidiary(-ies) nor the names
+**     of its contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "sortfilterproxymodel.h"
+#include <QtDebug>
+#include <QtQml>
+
+SortFilterProxyModel::SortFilterProxyModel(QObject *parent) : QSortFilterProxyModel(parent)
+{
+    connect(this, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SIGNAL(countChanged()));
+    connect(this, SIGNAL(rowsRemoved(QModelIndex,int,int)), this, SIGNAL(countChanged()));
+}
+
+int SortFilterProxyModel::count() const
+{
+    return rowCount();
+}
+
+QObject *SortFilterProxyModel::source() const
+{
+    return sourceModel();
+}
+
+void SortFilterProxyModel::setSource(QObject *source)
+{
+    setSourceModel(qobject_cast<QAbstractItemModel *>(source));
+}
+
+QByteArray SortFilterProxyModel::sortRole() const
+{
+    return roleNames().value(QSortFilterProxyModel::sortRole());
+}
+
+void SortFilterProxyModel::setSortRole(const QByteArray &role)
+{
+    QSortFilterProxyModel::setSortRole(roleKey(role));
+}
+
+void SortFilterProxyModel::setSortOrder(Qt::SortOrder order)
+{
+    QSortFilterProxyModel::sort(0, order);
+}
+
+QByteArray SortFilterProxyModel::filterRole() const
+{
+    return roleNames().value(QSortFilterProxyModel::filterRole());
+}
+
+void SortFilterProxyModel::setFilterRole(const QByteArray &role)
+{
+    QSortFilterProxyModel::setFilterRole(roleKey(role));
+}
+
+QString SortFilterProxyModel::filterString() const
+{
+    return filterRegExp().pattern();
+}
+
+void SortFilterProxyModel::setFilterString(const QString &filter)
+{
+    setFilterRegExp(QRegExp(filter, filterCaseSensitivity(), static_cast<QRegExp::PatternSyntax>(filterSyntax())));
+}
+
+SortFilterProxyModel::FilterSyntax SortFilterProxyModel::filterSyntax() const
+{
+    return static_cast<FilterSyntax>(filterRegExp().patternSyntax());
+}
+
+void SortFilterProxyModel::setFilterSyntax(SortFilterProxyModel::FilterSyntax syntax)
+{
+    setFilterRegExp(QRegExp(filterString(), filterCaseSensitivity(), static_cast<QRegExp::PatternSyntax>(syntax)));
+}
+
+QJSValue SortFilterProxyModel::get(int idx) const
+{
+    QJSEngine *engine = qmlEngine(this);
+    QJSValue value = engine->newObject();
+    if (idx >= 0 && idx < count()) {
+        QHash<int, QByteArray> roles = roleNames();
+        QHashIterator<int, QByteArray> it(roles);
+        while (it.hasNext()) {
+            it.next();
+            value.setProperty(QString::fromUtf8(it.value()), data(index(idx, 0), it.key()).toString());
+        }
+    }
+    return value;
+}
+
+int SortFilterProxyModel::roleKey(const QByteArray &role) const
+{
+    QHash<int, QByteArray> roles = roleNames();
+    QHashIterator<int, QByteArray> it(roles);
+    while (it.hasNext()) {
+        it.next();
+        if (it.value() == role)
+            return it.key();
+    }
+    return -1;
+}
+
+QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
+{
+    if (QAbstractItemModel *source = sourceModel())
+        return source->roleNames();
+    return QHash<int, QByteArray>();
+}
+
+bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    QRegExp rx = filterRegExp();
+    if (rx.isEmpty())
+        return true;
+    QAbstractItemModel *model = sourceModel();
+    if (filterRole().isEmpty()) {
+        QHash<int, QByteArray> roles = roleNames();
+        QHashIterator<int, QByteArray> it(roles);
+        while (it.hasNext()) {
+            it.next();
+            QModelIndex sourceIndex = model->index(sourceRow, 0, sourceParent);
+            QString key = model->data(sourceIndex, it.key()).toString();
+            if (key.contains(rx))
+                return true;
+        }
+        return false;
+    }
+    QModelIndex sourceIndex = model->index(sourceRow, 0, sourceParent);
+    if (!sourceIndex.isValid())
+        return true;
+    QString key = model->data(sourceIndex, roleKey(filterRole())).toString();
+    return key.contains(rx);
+}

--- a/frontend/support/sortfilterproxymodel.cpp
+++ b/frontend/support/sortfilterproxymodel.cpp
@@ -38,7 +38,7 @@
 **
 ****************************************************************************/
 
-#include "sortfilterproxymodel.h"
+#include "sortfilterproxymodel.hpp"
 #include <QtDebug>
 #include <QtQml>
 

--- a/frontend/support/sortfilterproxymodel.hpp
+++ b/frontend/support/sortfilterproxymodel.hpp
@@ -1,0 +1,100 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** You may use this file under the terms of the BSD license as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of Digia Plc and its Subsidiary(-ies) nor the names
+**     of its contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef SORTFILTERPROXYMODEL_H
+#define SORTFILTERPROXYMODEL_H
+
+#include <QtCore/qsortfilterproxymodel.h>
+#include <QtQml/qjsvalue.h>
+
+class SortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(QObject *source READ source WRITE setSource)
+
+    Q_PROPERTY(QByteArray sortRole READ sortRole WRITE setSortRole)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder)
+
+    Q_PROPERTY(QByteArray filterRole READ filterRole WRITE setFilterRole)
+    Q_PROPERTY(QString filterString READ filterString WRITE setFilterString)
+    Q_PROPERTY(FilterSyntax filterSyntax READ filterSyntax WRITE setFilterSyntax)
+
+    Q_ENUMS(FilterSyntax)
+
+public:
+    explicit SortFilterProxyModel(QObject *parent = 0);
+
+    QObject *source() const;
+    void setSource(QObject *source);
+
+    QByteArray sortRole() const;
+    void setSortRole(const QByteArray &role);
+
+    void setSortOrder(Qt::SortOrder order);
+
+    QByteArray filterRole() const;
+    void setFilterRole(const QByteArray &role);
+
+    QString filterString() const;
+    void setFilterString(const QString &filter);
+
+    enum FilterSyntax {
+        RegExp,
+        Wildcard,
+        FixedString
+    };
+
+    FilterSyntax filterSyntax() const;
+    void setFilterSyntax(FilterSyntax syntax);
+
+    int count() const;
+    Q_INVOKABLE QJSValue get(int index) const;
+
+signals:
+    void countChanged();
+
+protected:
+    int roleKey(const QByteArray &role) const;
+    QHash<int, QByteArray> roleNames() const;
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+};
+
+#endif // SORTFILTERPROXYMODEL_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3,7 +3,7 @@
 #include <QtQuick/QQuickWindow>
 
 #include "../backend/xchat/xchat.hpp"
-
+#include "../frontend/support/sortfilterproxymodel.hpp"
 
 int main(int argc, char *argv[])
 {
@@ -11,9 +11,11 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
 
     qmlRegisterType<Xchat>("xtrabytes.xcite.xchat", 1, 0, "Xchat");
+    qmlRegisterType<SortFilterProxyModel>("SortFilterProxyModel", 0, 1, "SortFilterProxyModel");
 
     QQmlApplicationEngine engine;
     engine.addImportPath("qrc:/");
+
     engine.load(QUrl(QLatin1String("qrc:/main.qml")));
     if (engine.rootObjects().isEmpty())
         return -1;

--- a/xcite.pro
+++ b/xcite.pro
@@ -40,14 +40,16 @@ QML_DESIGNER_IMPORT_PATH =
 SOURCES += main/main.cpp \
 	    backend/xchat/xchat.cpp \
 	    backend/xchat/xchataiml.cpp \
-	    backend/p2p/p2p.cpp 
+            backend/p2p/p2p.cpp \
+            frontend/support/sortfilterproxymodel.cpp
 
 RESOURCES += resources/resources.qrc
 RESOURCES += frontend/frontend.qrc
 
 HEADERS  += backend/xchat/xchat.hpp \
 	    backend/xchat/xchataiml.hpp \
-	    backend/p2p/p2p.hpp 
+            backend/p2p/p2p.hpp \
+            frontend/support/sortfilterproxymodel.hpp
 
 DISTFILES += \
     xcite.ico


### PR DESCRIPTION
Adds a new recent transactions table to the home section
Custom styled TableView: headers, rows, auto-colouring by tx type and custom scrollbar
Adds a QT-example table sorting type so column headers can be clicked to change the sort of the table data
Add double-click handler to table rows to popup a placeholder dialog

Fixes #22 