### PR TITLE
Add generic confirmation modal

### DIFF
--- a/frontend/Controls/ButtonModal.qml
+++ b/frontend/Controls/ButtonModal.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.1
+import QtQuick.Layouts 1.3
+
+Button {
+    property bool isPrimary: false
+    property alias label: label.text
+
+    Layout.fillWidth: true
+
+    signal buttonClicked
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: buttonClicked()
+        cursorShape: Qt.PointingHandCursor
+
+        hoverEnabled: true
+    }
+
+    background: Rectangle {
+        color: isPrimary ? "#0ED8D2" : "transparent"
+        radius: 4
+        border.width: 1
+        border.color: isPrimary ? "#0ED8D2" : "#616878"
+    }
+
+    Text {
+        id: label
+        anchors.fill: parent
+        color: isPrimary ? "#3e3e3e" : "#fff"
+        font.pixelSize: 18
+        font.family: "Roboto"
+        font.weight: isPrimary ? Font.Medium : Font.Light
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+    }
+}

--- a/frontend/Controls/ConfirmationModal.qml
+++ b/frontend/Controls/ConfirmationModal.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.1
+import QtQuick.Layouts 1.3
+
+Popup {
+    property int modalPadding: 20
+    property alias text: prompt.text
+    property alias title: title.text
+    property alias confirmText: btnConfirm.label
+    property alias cancelText: btnCancel.label
+
+    id: popup
+    x: (parent.width - width) / 2
+    y: (parent.height - height) / 2
+    modal: true
+    focus: true
+    dim: true
+    closePolicy: Popup.CloseOnEscape
+    padding: 0
+
+    signal confirmed
+    signal cancelled
+
+    background: Rectangle {
+        color: "#3A3E46"
+        radius: 4
+    }
+
+    RowLayout {
+        id: header
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: modalPadding
+        anchors.rightMargin: modalPadding
+        height: 48.61
+
+        Text {
+            id: title
+            Layout.fillWidth: true
+            verticalAlignment: Text.AlignVCenter
+            text: qsTr("PAYMENT CONFIRMATION")
+            color: "#E2E2E2"
+            font.pixelSize: 15
+            font.family: "Roboto"
+        }
+
+        IconButton {
+            anchors.verticalCenter: parent.verticalCenter
+            height: parent.height
+            Layout.preferredWidth: 20
+
+            iconColor: "#fff"
+            icon.source: "../icons/cross.svg"
+            icon.sourceSize.width: 10
+
+            onClicked: {
+                cancelled();
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        color: "#535353"
+        height: 1
+    }
+
+    ColumnLayout {
+        anchors.margins: modalPadding
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+
+        Text {
+            id: prompt
+            Layout.fillWidth: true
+            color: "#FFF7F7"
+            font.pixelSize: 18
+            wrapMode: Text.WordWrap
+        }
+
+        RowLayout {
+            spacing: 16
+
+            ButtonModal {
+                id: btnConfirm
+                isPrimary: true
+                onButtonClicked: {
+                    confirmed();
+                }
+            }
+
+            ButtonModal {
+                id: btnCancel
+                isPrimary: false
+                onButtonClicked: {
+                    cancelled();
+                }
+            }
+        }
+    }
+}

--- a/frontend/Controls/SideMenu.qml
+++ b/frontend/Controls/SideMenu.qml
@@ -117,6 +117,31 @@ Rectangle {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             checked: true
             padding: 0
+            onClicked: {
+                var component = Qt.createComponent("ConfirmationModal.qml");
+
+                if (component.status === Component.Ready) {
+                    var modal = component.createObject(xcite, {
+                        width: 511,
+                        height: 238,
+                        title: killSwitch.checked ? qsTr("ACTIVATE?") : qsTr("DEACTIVATE?"),
+                        text: qsTr("Are you sure?"),
+                        confirmText: qsTr("YES"),
+                        cancelText: qsTr("NO"),
+                    });
+
+                    modal.confirmed.connect(function() {
+                        modal.close();
+                    });
+
+                    modal.cancelled.connect(function() {
+                        killSwitch.checked = !killSwitch.checked;
+                        modal.close();
+                    });
+
+                    modal.open();
+                }
+            }
         }
     }
 }

--- a/frontend/frontend.qrc
+++ b/frontend/frontend.qrc
@@ -42,5 +42,7 @@
         <file>X-Board/Home/BalanceValueDiode.qml</file>
         <file>X-Board/Home/BalanceDiode.qml</file>
         <file>Controls/Popup.qml</file>
+        <file>Controls/ConfirmationModal.qml</file>
+        <file>Controls/ButtonModal.qml</file>
     </qresource>
 </RCC>

--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -15,6 +15,10 @@ ApplicationWindow {
     title: qsTr("Hello XCITE")
     color: "#2B2C31"
     
+    overlay.modal: Rectangle {
+        color: "#c92a2c31"
+    }
+
     StackView {
         id: mainRoot
         initialItem: LoginComponents.LoginForm {}


### PR DESCRIPTION
Adds an app-wide modal confirmation box used for simple yes/no prompts
Binds switch toggle at bottom left to example of dynamic usage (can be wrapped later)
Responding with yes should allow the switch toggle to change
Responding with no or clicking the close X at the top-right should cancel and revert the switch
Adds a couple of generic button types for use in other modals

Fixes #37 