### PR TITLE
Fix ListModel

### DIFF
--- a/frontend/X-Board/SendCoins/SendDiode.qml
+++ b/frontend/X-Board/SendCoins/SendDiode.qml
@@ -183,17 +183,17 @@ Controls.Diode {
                                        id: addressModel
 
                                        ListElement {
-                                           name: "Default"
+                                           name: "Candice"
                                            address: "BMy2BpwyJc5i7upNm5Vv8HMkwXqBR3kCxS"
                                        }
 
                                        ListElement {
-                                           name: "Main"
+                                           name: "Susan"
                                            address: "Jc5i7upNmBMy2Bpwy5Vv8HMkwXqBR3kCxS"
                                        }
 
                                        ListElement {
-                                           name: "Secondary"
+                                           name: "Timothy"
                                            address: "upNm5Vv8HMkBMy2BpwyJc5i7wXqBR3kCxS"
                                        }
                    }


### PR DESCRIPTION
Accidentally overwrote SendCoin ListModel on previous commit, should read names of actual contacts, not "main," "secondary," etc..