### PR TITLE
Fix Binding Loop Warning for Property Width

### DIFF
--- a/frontend/Login/LoginForm.qml
+++ b/frontend/Login/LoginForm.qml
@@ -66,7 +66,7 @@ Controls.ImagePolygonal {
 
         Controls.ButtonPlainText {
             anchors.horizontalCenter: parent.horizontalCenter
-            width: (dontHaveAccountText.width + signUpText.width)
+            width: (dontHaveAccountText.contentWidth + signUpText.contentWidth)
             onButtonClicked: {
                 mainRoot.push("SignUpForm.qml")
             }


### PR DESCRIPTION
I don't have the binding loop error on my end but after some research I think this should solve your problem. Issue #71 describes a binding loop. Binding loop seems to be due to referencing width which isn't explicit in a text unless so defined; in the case of a text width, contentWidth should be used instead. Closes #71