### PR TITLE
Fix additional binding loops on ButtonPlainText

### DIFF
--- a/frontend/Login/TwoFactorAuthForm.qml
+++ b/frontend/Login/TwoFactorAuthForm.qml
@@ -64,9 +64,7 @@ Controls.ImagePolygonal {
                     id: anotherAccountText
                     text: qsTr("Use another account?")
                     font.family: "Roboto Thin"
-                    Component.onCompleted: {
-                        Component.pointSize = 10
-                    }
+                    font.pointSize: 10
                     color: "#FFFFFF"
                     opacity: 0.8
                 }

--- a/frontend/Login/TwoFactorAuthForm.qml
+++ b/frontend/Login/TwoFactorAuthForm.qml
@@ -35,9 +35,9 @@ Controls.ImagePolygonal {
         }
 
         Controls.TextInputBlue {
-          anchors.horizontalCenter: parent.horizontalCenter
-          placeholder: "******"
-          echoMode: TextInput.Password
+            anchors.horizontalCenter: parent.horizontalCenter
+            placeholder: "******"
+            echoMode: TextInput.Password
         }
 
         Controls.ButtonSimple {
@@ -52,7 +52,7 @@ Controls.ImagePolygonal {
 
         Controls.ButtonPlainText {
             anchors.horizontalCenter: parent.horizontalCenter
-            width: (anotherAccountText.width + goBackText.width)
+            width: (anotherAccountText.contentWidth + goBackText.contentWidth)
             onButtonClicked: {
                 mainRoot.push("LoginForm.qml")
             }
@@ -64,7 +64,9 @@ Controls.ImagePolygonal {
                     id: anotherAccountText
                     text: qsTr("Use another account?")
                     font.family: "Roboto Thin"
-                    font.pointSize: 10
+                    Component.onCompleted: {
+                        Component.pointSize = 10
+                    }
                     color: "#FFFFFF"
                     opacity: 0.8
                 }


### PR DESCRIPTION
Updating proper usage of parent-child relationship in TwoFactorAuthForm. 

Much like previous binding loop, binding loop on text width appears to pop up due to setting width without considerations for width the text actually occupies. 

Wait for component size to set before setting the actual point size. Should fix your binding loop, let me know. Thanks!

Closes #83 