### PR TITLE
Auto-resize balance diode values so they don't overflow

### DIFF
--- a/frontend/Controls/BalanceItem.qml
+++ b/frontend/Controls/BalanceItem.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQuick.Controls 2.2
 import "../Controls" as Controls
 
 Item {
@@ -9,6 +10,7 @@ Item {
     property alias valueFont: value.font
     property alias valueColor: value.color
     property alias valuePrefix: prefix.text
+    property alias valueWidth: value.width
 
     anchors.left: parent.left
     anchors.right: parent.right
@@ -24,20 +26,23 @@ Item {
         anchors.topMargin: 16
     }
 
-    Text {
+    Label {
         id: value
         color: cBalanceValue
         font.family: 'Roboto Condensed'
         font.weight: Font.Light
         font.pixelSize: 54
+        minimumPixelSize: 10
+        fontSizeMode: Text.Fit
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignRight
         anchors.right: parent.right
+        leftPadding: 30
 
-        Text {
+        Label {
             id: prefix
-            anchors.bottom: parent.bottom
-            anchors.right: parent.left
-            anchors.rightMargin: 6
-            anchors.bottomMargin: 10
+            anchors.fill: parent
+            verticalAlignment: Text.AlignVCenter
             color: "#e3e3e3"
             font.pixelSize: 14
             font.family: "Roboto"

--- a/frontend/X-Board/Home/BalanceDiode.qml
+++ b/frontend/X-Board/Home/BalanceDiode.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.2
 import "../../Controls" as Controls
 
 Rectangle {
@@ -21,6 +22,7 @@ Rectangle {
         value: "175,314"
         anchors.top: parent.top
         anchors.topMargin: 63
+        valueWidth: 225
     }
 
     Controls.BalanceItem {
@@ -29,6 +31,7 @@ Rectangle {
         valuePrefix: qsTr("XBY")
         value: "22,695"
         anchors.top: balance.bottom
+        valueWidth: 180
     }
 
     Controls.BalanceItem {
@@ -41,5 +44,6 @@ Rectangle {
         valueFont.weight: Font.Normal
         anchors.top: unconfirmedBalance.bottom
         anchors.topMargin: 30
+        valueWidth: 250
     }
 }

--- a/frontend/X-Board/Home/BalanceValueDiode.qml
+++ b/frontend/X-Board/Home/BalanceValueDiode.qml
@@ -19,5 +19,6 @@ Rectangle {
         value: "37,621"
         valuePrefix: qsTr("$")
         anchors.top: diodeHeader.bottom
+        valueWidth: 340
     }
 }


### PR DESCRIPTION
In-the-meantime fix for large values in the balance diode, scales the font to fit:

<img width="408" alt="screen shot 2018-02-18 at 18 20 44" src="https://user-images.githubusercontent.com/36036056/36355398-7c726c58-14da-11e8-9721-64c2b92b266f.png">
