### PR TITLE
Fix Send Payment Button on Small Devices

### DIFF
--- a/frontend/XCITE/SendCoins/Layout.qml
+++ b/frontend/XCITE/SendCoins/Layout.qml
@@ -30,7 +30,7 @@ RowLayout {
         SendDiode {
             anchors.top: parent.top
             Layout.fillWidth: true
-            height: childrenRect.height
+            height: xcite.height < 850 ? xcite.height : childrenRect.height
         }
     }
 

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -6,7 +6,6 @@ import QtQuick.Window 2.2
 import AddressBookModel 0.1
 
 import "../../Controls" as Controls
-import "../Home" as Home
 
 Controls.Diode {
     property int networkFee: 1

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -6,6 +6,7 @@ import QtQuick.Window 2.2
 import AddressBookModel 0.1
 
 import "../../Controls" as Controls
+import "../Home" as Home
 
 Controls.Diode {
     property int networkFee: 1
@@ -277,18 +278,18 @@ Controls.Diode {
             Layout.fillWidth: true
             Layout.leftMargin: 22
             Layout.rightMargin: 22
-            height: (Screen.height > 900) ? 1 : 0
+            height: (xcite.height > 850) ? 1 : 0
             color: "#535353"
         }
 
         // Send Payment
         Controls.ButtonModal {
             Layout.fillWidth: true
-            Layout.topMargin: Screen.height > 900 ? 35 : -75
-            width: Screen.height < 900 ? 500 : -200
+            Layout.topMargin: xcite.height > 850 ? 35 : -75
+            width: Screen.height < 850 ? 500 : -200
             Layout.bottomMargin: 35
             Layout.leftMargin: 175
-            Layout.rightMargin: Screen.height < 900 ? 400 : 175
+            Layout.rightMargin: xcite.height < 850 ? 400 : 175
             label.font.family: "Roboto"
             label.font.weight: Font.Medium
             label.font.letterSpacing: 3

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
+import QtQuick.Window 2.2
 
 import AddressBookModel 0.1
 
@@ -276,17 +277,18 @@ Controls.Diode {
             Layout.fillWidth: true
             Layout.leftMargin: 22
             Layout.rightMargin: 22
-            height: 1
+            height: (Screen.height > 900) ? 1 : 0
             color: "#535353"
         }
 
         // Send Payment
         Controls.ButtonModal {
             Layout.fillWidth: true
-            Layout.topMargin: 35
+            Layout.topMargin: Screen.height > 900 ? 35 : -75
+            width: Screen.height < 900 ? 500 : -200
             Layout.bottomMargin: 35
-            Layout.leftMargin: 172
-            Layout.rightMargin: 172
+            Layout.leftMargin: 175
+            Layout.rightMargin: Screen.height < 900 ? 400 : 175
             label.font.family: "Roboto"
             label.font.weight: Font.Medium
             label.font.letterSpacing: 3


### PR DESCRIPTION
Send Payment was getting clipped on small screens, fixes by bumping up send payment and removing divider on screens smaller than 900 pixels

Please look over this one extra careful, any time a button that sends a payment is altered extra care should be taken!