### PR TITLE
Differentiate between addressbook sends and manual sends on SendCoins

### DIFF
--- a/frontend/Controls/ButtonModal.qml
+++ b/frontend/Controls/ButtonModal.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 
 Button {
     property bool isPrimary: false
+    property bool isDanger: false
     property alias label: label
     property string labelText: label.text || qsTr("OK")
     property real buttonHeight: parent.height
@@ -22,18 +23,18 @@ Button {
     }
 
     background: Rectangle {
-        color: isPrimary ? "#0ED8D2" : "transparent"
+        color: isDanger ? "#d80e0e" : (isPrimary ? "#0ED8D2" : "transparent")
         radius: 4
         height: buttonHeight
         border.width: 1
-        border.color: isPrimary ? "#0ED8D2" : "#616878"
+        border.color: isDanger ? "#d80e0e" : (isPrimary ? "#0ED8D2" : "#616878")
         anchors.verticalCenter: parent.verticalCenter
     }
 
     Text {
         id: label
         anchors.fill: parent
-        color: isPrimary ? "#3e3e3e" : "#fff"
+        color: isDanger ? "#fff" : (isPrimary ? "#3e3e3e" : "#fff")
         font.pixelSize: 18
         text: labelText
         font.family: "Roboto"

--- a/frontend/Controls/TextInput.qml
+++ b/frontend/Controls/TextInput.qml
@@ -15,5 +15,7 @@ TextField {
     background: Rectangle {
         color: "#2A2C31"
         radius: 4
+        border.width: parent.activeFocus ? 2 : 0
+        border.color: "#0ED8D2"
     }
 }

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -109,6 +109,12 @@ Controls.Diode {
                     Layout.preferredWidth: 516
                     topPadding: 10
                     bottomPadding: 10
+
+                    Connections {
+                        onTextEdited: {
+                            addressBook.currentIndex = -1
+                        }
+                    }
                 }
 
                 Label {
@@ -290,8 +296,10 @@ Controls.Diode {
             label.font.family: "Roboto"
             label.font.weight: Font.Medium
             label.font.letterSpacing: 3
-            label.text: qsTr("SEND PAYMENT")
+            label.text: addressBook.currentIndex < 0 ? qsTr("SEND QUICK PAYMENT") : qsTr(
+                                                           "SEND PAYMENT")
             isPrimary: true
+            isDanger: addressBook.currentIndex < 0
             buttonHeight: 60
 
             onButtonClicked: {
@@ -304,11 +312,20 @@ Controls.Diode {
                     return
                 }
 
-                var item = addressBook.currentItem.item
+                var address, text, amount = Number(formAmount.text)
 
-                var text = qsTr("Are you sure you want to send") + " " + Number(
-                            formAmount.text).toFixed(
-                            2) + " " + "to" + " " + item.name + " (" + item.address + ")?"
+                if (addressBook.currentIndex < 0) {
+                    // Quick send
+                    address = formAddress.text.trim()
+                    text = qsTr("This address is not in your addressbook.\n\nAre you sure you want to send")
+                            + " " + amount + "XBY " + "to " + address + "?"
+                } else {
+                    var item = addressBook.currentItem.item
+                    address = item.address
+
+                    text = qsTr("Are you sure you want to send") + " " + amount
+                            + "XBY " + "to" + " " + item.name + " (" + address + ")?"
+                }
 
                 confirmationModal({
                                       title: qsTr("PAYMENT CONFIRMATION"),
@@ -316,14 +333,15 @@ Controls.Diode {
                                       confirmText: qsTr("YES, SEND"),
                                       cancelText: qsTr("NO, CANCEL")
                                   }, function () {
-                                      testnetSendFrom('', item.address,
-                                                      Number(formAmount.text))
+                                      testnetSendFrom('', address, amount)
                                   })
             }
         }
     }
 
     function selectItem(item) {
-        formAddress.text = item.address
+        if (item) {
+            formAddress.text = item.address
+        }
     }
 }


### PR DESCRIPTION
Should deselect the addressbook when you change the address in the form
Should change the button to red and change the text
Should display a warning message in the confirmation prompt that this is not an addressbook send
Addressbook sends should work as normal