### PR TITLE
Search results are now more specific

### DIFF
--- a/frontend/Controls/SearchBox.qml
+++ b/frontend/Controls/SearchBox.qml
@@ -83,22 +83,6 @@ Item {
                     showSearchResults()
                 }
             }
-
-            /*
-        MouseArea {
-            id: searchFieldMouseArea
-            anchors.fill: parent
-            hoverEnabled: true
-            onHoveredChanged: {
-                if (containsMouse) {
-                    root.color= "#454951"
-                }
-                else {
-                    root.color= "#3A3E46"
-                }
-            }
-        }
-        */
         }
 
         Item {

--- a/frontend/Controls/SearchBoxResults.qml
+++ b/frontend/Controls/SearchBoxResults.qml
@@ -26,23 +26,39 @@ Rectangle {
         filterResult(text)
     }
 
+    property int totalChildren: -1
+
+    function countTotalChildren() {
+        if (totalChildren >= 0) {
+            return totalChildren
+        }
+
+        totalChildren = 0
+
+        // Each category
+        for (var i = 0; i < searchBoxResultsId.children.length; i++) {
+            // Count items in each category
+            totalChildren += searchBoxResultsId.children[i].children.length
+        }
+        return totalChildren
+    }
+
     function filterResult(textToSearch) {
         //traverse results and set to visible
-        var isAnyCategoryVisible = false
+        var totalVisibleChildrenCount = 0
+
         textToSearch = textToSearch.toLowerCase()
         for (var i = 0; i < searchBoxResultsId.children.length; i++) {
 
             // Show or hide categories. They hide themselves if no child is visible or available
-            var isVisibleCategory = searchBoxResultsId.children[i].filterResult(
+            totalVisibleChildrenCount += searchBoxResultsId.children[i].filterResult(
                         textToSearch)
-
-            if (isVisibleCategory) {
-                isAnyCategoryVisible = true
-            }
         }
 
-        // hide results box if no category is visible
-        searchResultsBox.visible = isAnyCategoryVisible
+        // hide results box if search is not specific enough
+        var totalChildrenCount = countTotalChildren()
+        var matchRate = (totalVisibleChildrenCount / totalChildrenCount)
+        searchResultsBox.visible = matchRate > 0 && matchRate < 0.30
     }
 
     Column {

--- a/frontend/Controls/SearchBoxResultsCategory.qml
+++ b/frontend/Controls/SearchBoxResultsCategory.qml
@@ -31,18 +31,20 @@ Rectangle {
     function filterResult(textToSearch) {
         // traverse results and set to visible
         var isAnyChildVisible = false
+        var visibleChildrenCount = 0
         for (var i = 0; i < searchResultsCategoryRowLayoutId.children.length; i++) {
             var visibleChild = searchResultsCategoryRowLayoutId.children[i].filterResult(
                         textToSearch)
 
             if (visibleChild) {
                 isAnyChildVisible = true
+                visibleChildrenCount += 1
             }
         }
 
         // show category only if at least an item is visible
         visible = isAnyChildVisible
-        return visible
+        return visibleChildrenCount
     }
 
     // Results is content of category (can be added as children)


### PR DESCRIPTION
Search results were too sensitive. For example, if you wrote "x", then all modules matched because they all have an X in their names.

Now, a match rate of over 0 and under 30 percent would be required to show the results. This rate can be adjusted as more items are added to the search results.