### PR TITLE
Change RPC used for sending coins to avoid insufficient fund errors

### DIFF
--- a/backend/testnet/testnet.cpp
+++ b/backend/testnet/testnet.cpp
@@ -8,6 +8,12 @@ void Testnet::sendFrom(QString account, QString address, qreal amount) {
     client->request("sendfrom", params);
 }
 
+void Testnet::sendToAddress(QString address, qreal amount) {
+    QJsonArray params = {address, amount};
+
+    client->request("sendtoaddress", params);
+}
+
 void Testnet::getAccountAddress(QString account) {
     QJsonArray params = {
         account
@@ -78,6 +84,8 @@ void Testnet::onResponse(QString command, QJsonArray params, QJsonObject res)
             walletError("Invalid address: " + params[0].toString());
         }
     } else if (command == "sendfrom") {
+        walletSuccess(res["result"].toString());
+    } else if (command == "sendtoaddress") {
         walletSuccess(res["result"].toString());
     }
 }

--- a/backend/testnet/testnet.hpp
+++ b/backend/testnet/testnet.hpp
@@ -119,6 +119,7 @@ signals:
 public Q_SLOTS:
     void request(QString command);
     void sendFrom(QString account, QString address, qreal amount);
+    void sendToAddress(QString address, qreal amount);
     void getAccountAddress(QString account);
     void validateAddress(QString);
     void onResponse(QString, QJsonArray, QJsonObject);

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -320,7 +320,8 @@ Controls.Diode {
                                       confirmText: qsTr("YES, SEND"),
                                       cancelText: qsTr("NO, CANCEL")
                                   }, function () {
-                                      testnetSendFrom('', address, amount)
+                                      testnetSendToAddress(item.address, Number(
+                                                               formAmount.text))
                                   })
             }
         }

--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -41,6 +41,7 @@ ApplicationWindow {
     signal xChatMessageReceived(string message, date datetime)
     signal testnetRequest(string request)
     signal testnetSendFrom(string account, string address, real amount)
+    signal testnetSendToAddress(string address, real amount)
     signal testnetValidateAddress(string address)
     signal testnetGetAccountAddress(string account)
     signal localeChange(string locale)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char *argv[])
     // FauxWallet
     QObject::connect(engine.rootObjects().first(), SIGNAL(testnetRequest(QString)), &wallet, SLOT(request(QString)));
     QObject::connect(engine.rootObjects().first(), SIGNAL(testnetSendFrom(QString, QString, qreal)), &wallet, SLOT(sendFrom(QString, QString, qreal)));
+    QObject::connect(engine.rootObjects().first(), SIGNAL(testnetSendToAddress(QString, qreal)), &wallet, SLOT(sendToAddress(QString, qreal)));
     QObject::connect(engine.rootObjects().first(), SIGNAL(testnetGetAccountAddress(QString)), &wallet, SLOT(getAccountAddress(QString)));
     QObject::connect(engine.rootObjects().first(), SIGNAL(testnetValidateAddress(QString)), &wallet, SLOT(validateAddress(QString)));
     QObject::connect(&wallet, SIGNAL(response(QVariant)), engine.rootObjects().first(), SLOT(testnetResponse(QVariant)));


### PR DESCRIPTION
Previously we were using `sendfrom` with the default account as a parameter. This would result in "insufficient funds" if that account happened to be empty.
This changes to use `sendToAddress` which will attempt to send funds from whichever account has funds