### PR TITLE
Fix CheckBoxBlue layout and text property for QT5.10

### DIFF
--- a/frontend/Controls/CheckBoxBlue.qml
+++ b/frontend/Controls/CheckBoxBlue.qml
@@ -4,13 +4,13 @@ import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 
 CheckBox {
-    id: checkboxBlue
-
-    property string text
+    id: control
 
     indicator: Rectangle {
         implicitWidth: 16
         implicitHeight: 16
+        x: control.leftPadding
+        y: parent.height / 2 - height / 2
         radius: 2
         color: "black"
         border.color: "#10B9C5"
@@ -24,11 +24,12 @@ CheckBox {
             anchors.margins: 3
             anchors.fill: parent
         }
-
     }
 
     contentItem: Text {
         color: "#10B9C5"
-        text: checkboxBlue.text
+        text: control.text
+        verticalAlignment: Text.AlignVCenter
+        leftPadding: control.indicator.width + control.spacing
     }
 }


### PR DESCRIPTION
Qt5.10 upgrade made CheckBoxBlue unhappy, breaking background when transitioning to the dashboard. It's now happy again.

Fixes #175 