### PR TITLE
Fix tooltip width for non-GMT timezones

### DIFF
--- a/frontend/XCITE/Home/ChartDiode.qml
+++ b/frontend/XCITE/Home/ChartDiode.qml
@@ -86,17 +86,17 @@ Controls.Diode {
 
                 var pos = priceChartView.mapToPosition(pt)
 
-                tooltip.x = (pos.x + tooltip.width
-                             > priceChartView.width) ? pos.x - tooltip.width : pos.x
-                tooltip.y = mouse.y
-                price.text = "$" + pt.y.toFixed(5)
-
-                bullet.x = pos.x - (bullet.width / 2)
-                bullet.y = pos.y - (bullet.height / 2)
-
                 var d = new Date()
                 d.setTime(pt.x)
                 date.text = d.toString()
+                price.text = "$" + pt.y.toFixed(5)
+
+                tooltip.x = (pos.x + tooltip.width
+                             > priceChartView.width) ? pos.x - tooltip.width : pos.x
+                tooltip.y = mouse.y
+
+                bullet.x = pos.x - (bullet.width / 2)
+                bullet.y = pos.y - (bullet.height / 2)
             }
         }
 
@@ -205,7 +205,7 @@ Controls.Diode {
         id: tooltip
         color: "#2A2C31"
         height: 45
-        width: 210
+        width: childrenRect.width
         radius: 4
         visible: false
 


### PR DESCRIPTION
Should address: 
![unknown-1](https://user-images.githubusercontent.com/36036056/37555625-63798e12-29e2-11e8-88be-245aa2e98d4f.png)
