### PR TITLE
Add robot tab that acts as a debug console

### DIFF
--- a/backend/testnet/xchattestnetclient.cpp
+++ b/backend/testnet/xchattestnetclient.cpp
@@ -8,7 +8,7 @@ void XchatTestnetClient::WriteBalance(QString account)
     QVariantList params = { account };
 
     Testnet wallet;
-    wallet.request("getbalance", params);
+    wallet.request("chat", "getbalance", params);
 }
 
 void XchatTestnetClient::CompleteWriteBalance(XchatObject *xchatobject, QString balance)
@@ -21,7 +21,7 @@ void XchatTestnetClient::WriteDumpprivkey(QString account)
     QVariantList params = { account };
 
     Testnet wallet;
-    wallet.request("dumpprivkey", params);
+    wallet.request("chat", "dumpprivkey", params);
 }
 
 void XchatTestnetClient::CompleteDumpprivkey(XchatObject *xchatobject, QString dumpprivkey)
@@ -34,7 +34,7 @@ void XchatTestnetClient::WriteGetBlock(QString blockHash)
     QVariantList params = { blockHash };
 
     Testnet wallet;
-    wallet.request("getblock", params);
+    wallet.request("chat", "getblock", params);
 }
 
 void XchatTestnetClient::CompleteGetBlock(XchatObject *xchatobject, QJsonArray blockdata)

--- a/backend/xchat/xchat.cpp
+++ b/backend/xchat/xchat.cpp
@@ -30,7 +30,6 @@ void XchatObject::Initialize() {
 }
 
 void XchatObject::SubmitMsgCall(const QString &msg) {
-
     QString message;
     bool keyWordUsedUserInput = this->CheckUserInputForKeyWord(msg);
     bool keyWordUsedAIInput = this->CheckAIInputForKeyWord(m_pXchatAiml->getResponse(msg));

--- a/frontend/Controls/ButtonIcon.qml
+++ b/frontend/Controls/ButtonIcon.qml
@@ -13,6 +13,7 @@ Item {
     property int size: 40
     property int imageOffsetX: 0
     property int imageOffsetY: 0
+    property int imageRotation: 0
 
     property alias imageSource: image.source
     property alias hoverEnabled: mouseArea.hoverEnabled
@@ -49,6 +50,8 @@ Item {
         mipmap: true
         anchors.horizontalCenter: parent.horizontalCenter
 
+        rotation: imageRotation
+
         transform: Translate {
             x: imageOffsetX
             y: imageOffsetY
@@ -67,6 +70,7 @@ Item {
         source: image
         color: getDefaultColor()
 
+        rotation: imageRotation
         transform: Translate {
             x: imageOffsetX
             y: imageOffsetY

--- a/frontend/Controls/DiodeHeader.qml
+++ b/frontend/Controls/DiodeHeader.qml
@@ -11,6 +11,7 @@ Rectangle {
 
     property alias menuLabelText: menuLabel.text
     property alias text: label.text
+    property alias iconRotation: menuLabel.iconRotation
     property alias iconSource: menuLabel.iconSource
     property alias iconSize: menuLabel.iconSize
     property alias iconOnly: menuLabel.iconOnly

--- a/frontend/Controls/DiodeHeaderMenu.qml
+++ b/frontend/Controls/DiodeHeaderMenu.qml
@@ -7,6 +7,7 @@ RowLayout {
 
     property alias text: menuLabel.text
     property string iconSource: "../icons/dropdown-arrow.svg"
+    property int iconRotation: 0
     property int iconSize: 5
     property bool iconOnly: false
 
@@ -31,9 +32,11 @@ RowLayout {
     }
 
     ButtonIcon {
+        id: icon
         width: parent.height
         anchors.verticalCenter: parent.verticalCenter
         imageSource: iconSource
+        imageRotation: iconRotation
         size: iconSize
     }
 }

--- a/frontend/Controls/IconButton.qml
+++ b/frontend/Controls/IconButton.qml
@@ -13,8 +13,7 @@ Button {
 
     text: ""
 
-    background: Rectangle {
-        color: "transparent"
+    background: Item {
     }
 
     MouseArea {

--- a/frontend/DashboardForm.qml
+++ b/frontend/DashboardForm.qml
@@ -80,7 +80,6 @@ Item {
 
     XchatPopup {
         id: xChatPopup
-        visible: false
     }
 
     Timer {

--- a/frontend/Network.qml
+++ b/frontend/Network.qml
@@ -4,26 +4,26 @@ Item {
     property var handler
 
     function getAccountAddress(name) {
-        handler.request('getaccountaddress', [name])
+        handler.request('ui', 'getaccountaddress', [name])
     }
 
     function getBalance() {
-        handler.request('getbalance', [])
+        handler.request('ui', 'getbalance', [])
     }
 
     function listAccounts() {
-        handler.request('listaccounts', [])
+        handler.request('ui', 'listaccounts', [])
     }
 
     function listTransactions() {
-        handler.request('listtransactions', [])
+        handler.request('ui', 'listtransactions', [])
     }
 
     function sendToAddress(address, amount) {
-        handler.request('sendtoaddress', [address, amount])
+        handler.request('ui', 'sendtoaddress', [address, amount])
     }
 
     function validateAddress(address) {
-        handler.request('validateaddress', [address])
+        handler.request('ui', 'validateaddress', [address])
     }
 }

--- a/frontend/X-Chat/Conversation.qml
+++ b/frontend/X-Chat/Conversation.qml
@@ -1,88 +1,86 @@
-import QtQuick 2.6
+import QtQuick 2.7
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.3
-import XChatConversationModel 0.1
 import "../Theme" 1.0
 
 ColumnLayout {
-    Connections {
-        target: xcite
-        onXChatMessageReceived: {
-            add(message, datetime, false)
-        }
+    property alias model: view.model
+    property alias view: view
 
-        // TODO: Temporary placeholder content
-        Component.onCompleted: {
-            var now = Date.now()
+    property color localTextColor: '#fff'
+    property color localBorderColor: '#727989'
+    property color localBackgroundColor: 'transparent'
+    property color remoteTextColor: '#000'
+    property color remoteBackgroundColor: Theme.primaryHighlight
+    property color remoteBorderColor: 'transparent'
+    property int messageSpacing: 12
+    property int timestampSpacing: 4
+    property bool simpleLayout: false
 
-            add("Heading downtown?", new Date(now - 180000), true)
-            add("Absolutely, catching a show.", new Date(now - 120000), false)
-            add("We'll catch up later!", new Date(now), true)
-        }
-    }
+    anchors.fill: parent
 
     function add(message, datetime, isMine) {
-        conversation.model.addMessage(message, datetime, isMine)
+        if (model) {
+            model.addMessage(message, datetime, isMine)
+        }
     }
 
     ListView {
-        id: conversation
-        spacing: 12
+        id: view
+        spacing: messageSpacing
 
         Layout.fillHeight: true
         Layout.fillWidth: true
-        Layout.leftMargin: 18.9
-        Layout.rightMargin: 18.9
+        Layout.leftMargin: viewMargin
+        Layout.rightMargin: viewMargin
         Layout.topMargin: 5
         Layout.bottomMargin: 5
-
         verticalLayoutDirection: ListView.BottomToTop
-        model: XChatConversationModel {
-        }
-
         clip: true
 
         delegate: Column {
-            anchors.left: isMine ? undefined : parent.left
-            anchors.right: isMine ? parent.right : undefined
-            spacing: 4.7
+            spacing: timestampSpacing
+
+            anchors.left: simpleLayout ? undefined : (model.isMine ? undefined : parent.left)
+            anchors.right: simpleLayout ? undefined : (model.isMine ? parent.right : undefined)
 
             Row {
-                anchors.left: isMine ? undefined : parent.left
-                anchors.right: isMine ? parent.right : undefined
+                TextArea {
+                    text: model.message
+                    readOnly: true
+                    persistentSelection: true
+                    selectByMouse: true
+                    color: model.isMine ? localTextColor : remoteTextColor
+                    wrapMode: TextEdit.Wrap
+                    font.pixelSize: 11
+                    selectionColor: Theme.primaryHighlight
+                    selectedTextColor: '#000'
 
-                Label {
-                    id: messageText
-                    topPadding: 7.3
-                    bottomPadding: 6
-                    leftPadding: 7.05
-                    rightPadding: 8.05
+                    topPadding: simpleLayout ? 0 : 7.3
+                    bottomPadding: simpleLayout ? 0 : 6
+                    leftPadding: simpleLayout ? 0 : 7.05
+                    rightPadding: simpleLayout ? 0 : 8.05
 
                     background: Rectangle {
-                        color: isMine ? "transparent" : Theme.primaryHighlight
-                        border.color: isMine ? "#727989" : "transparent"
                         anchors.fill: parent
+                        color: model.isMine ? localBackgroundColor : remoteBackgroundColor
+                        border.color: model.isMine ? localBorderColor : remoteBorderColor
                         radius: 2
                     }
 
-                    text: model.message
-                    color: isMine ? "white" : "black"
-                    font.pixelSize: 11
-                    lineHeight: 1.2
-                    wrapMode: Label.WordWrap
-
                     Component.onCompleted: {
-                        if (paintedWidth > conversation.width) {
-                            width = conversation.width
+                        if (width > view.width) {
+                            width = view.width
                         }
                     }
                 }
             }
 
             Label {
+                visible: model.datetime
                 font.pixelSize: 10
-                anchors.left: isMine ? undefined : parent.left
-                anchors.right: isMine ? parent.right : undefined
+                anchors.left: model.isMine ? undefined : parent.left
+                anchors.right: model.isMine ? parent.right : undefined
                 text: Qt.formatDateTime(model.datetime, 'h:mm ap')
                 color: "white"
             }

--- a/frontend/X-Chat/Header.qml
+++ b/frontend/X-Chat/Header.qml
@@ -4,7 +4,12 @@ import QtQuick.Layouts 1.3
 import "../Controls" as Controls
 
 ColumnLayout {
-    anchors.fill: parent
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    Layout.maximumHeight: 46
+
+    signal tabChanged(string newActiveTab)
 
     Controls.DiodeHeader {
         text: qsTr("X-CHAT")
@@ -12,10 +17,15 @@ ColumnLayout {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
+        iconRotation: xChatPopup.state === "minimal" ? 180 : 0
+        iconOnly: true
 
         MouseArea {
             id: mouseArea
-            anchors.fill: parent
+            anchors.top: parent.top
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            width: 48
             hoverEnabled: xChatPopup.visible === false
             cursorShape: Qt.PointingHandCursor
 
@@ -35,27 +45,25 @@ ColumnLayout {
             Controls.ButtonIcon {
                 imageSource: "../icons/friend-request.svg"
                 size: 22
-                isSelected: xChatPopup.mode === "friends"
-                onButtonClicked: {
-                    xChatPopup.mode = "friends"
-                }
+                isSelected: xChatPopup.activeTab === "friends"
+                onButtonClicked: tabChanged('friends')
             }
 
             Controls.ButtonIcon {
                 imageSource: "../icons/robot.svg"
                 size: 25
-                isSelected: xChatPopup.mode === "robot"
-                onButtonClicked: {
-                    xChatPopup.mode = "robot"
-                }
+                isSelected: xChatPopup.activeTab === "robot"
+                onButtonClicked: tabChanged('robot')
             }
         }
     }
 
+    /*
     Item {
         // Contact details
+        visible: false
         Layout.fillWidth: true
-        height: 44.5
+        Layout.preferredHeight: 44.5
 
         RowLayout {
             anchors.fill: parent
@@ -65,7 +73,8 @@ ColumnLayout {
             Controls.IconButton {
                 anchors.verticalCenter: parent.verticalCenter
                 img.source: "../icons/left-arrow.svg"
-                img.sourceSize.height: 10
+                img.sourceSize.height: 11
+                img.sourceSize.width: 10
                 height: parent.height
             }
 
@@ -80,9 +89,11 @@ ColumnLayout {
                 anchors.verticalCenter: parent.verticalCenter
                 img.source: "../icons/phone-call.svg"
                 img.sourceSize.width: 22
+                img.sourceSize.height: 22
                 iconColor: "#acb6ce"
                 height: parent.height
             }
         }
     }
+    */
 }

--- a/frontend/XchatPopup.qml
+++ b/frontend/XchatPopup.qml
@@ -2,21 +2,44 @@ import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
+import XChatConversationModel 0.1
+
 import "X-Chat" as XChat
+import "Theme" 1.0
 
 import "Controls" as Controls
 
 Item {
     readonly property color cBackground: "#3a3e47"
-    property string mode: "robot"
+    readonly property real viewMargin: 10
+    property string activeTab: xChatSettings.activeTab
+
+    property var consoleCommandBuffer: []
+    property var consoleCommandCompletion: ['addmultisigaddress', 'addnode', 'backupwallet', 'createmultisig', 'createrawtransaction', 'decoderawtransaction', 'dumpprivkey', 'encryptwallet', 'getaccount', 'getaccountaddress', 'getaddednodeinfo', 'getaddressesbyaccount', 'getbalance', 'getbestblockhash', 'getblock', 'getblockcount', 'getblockhash', 'getconnectioncount', 'getinfo', 'getnewaddress', 'getpeerinfo', 'getrawmempool', 'getrawtransaction', 'getreceivedbyaccount', 'getreceivedbyaddress', 'gettransaction', 'gettxout', 'gettxoutsetinfo', 'help', 'importprivkey', 'keypoolrefill', 'listaccounts', 'listaddressgroupings', 'listlockunspent', 'listreceivedbyaccount', 'listreceivedbyaddress', 'listsinceblock', 'listtransactions', 'listunspent', 'lockunspent', 'makekeypair', 'move', 'sendalert', 'sendfrom', 'sendmany', 'sendrawtransaction', 'sendtoaddress', 'setaccount', 'setmininput', 'settxfee', 'signmessage', 'signrawtransaction', 'stop', 'validateaddress', 'verifychain', 'verifymessage']
+
+    property int consoleCommandBufferIdx: -1
 
     id: xChatPopup
     anchors.right: parent.right
     anchors.bottom: parent.bottom
     width: 318
     smooth: true
+    z: 100
 
-    state: "minimal"
+    Connections {
+        target: header
+        onTabChanged: {
+            xChatSettings.activeTab = newActiveTab
+            xChatTextInput.forceActiveFocus()
+        }
+    }
+
+    Component.onCompleted: {
+        xChatTextInput.forceActiveFocus()
+    }
+
+    state: xChatSettings.sizeState
+
     states: [
         State {
             name: "minimal"
@@ -45,6 +68,7 @@ Item {
 
     function toggle() {
         state = state === 'full' ? 'minimal' : 'full'
+        xChatSettings.sizeState = state
     }
 
     function focus(e) {
@@ -55,10 +79,16 @@ Item {
         var text = xChatTextInput.text.trim()
 
         if (text.length > 0) {
-            conversation.add(text, new Date(), true)
-            xchatSubmitMsgSignal(text, '')
+            var isRobot = activeTab === 'robot'
+            var activeConversation = isRobot ? robot : conversation
+
+            activeConversation.add(text, isRobot ? null : new Date(), true)
+            activeConversation.submit(text)
+
             xChatTextInput.text = ''
         }
+
+        xChatTextInput.forceActiveFocus()
     }
 
     Rectangle {
@@ -73,11 +103,95 @@ Item {
             anchors.fill: parent
 
             XChat.Header {
+                id: header
+                Layout.fillWidth: true
             }
 
-            XChat.Conversation {
-                id: conversation
+            Item {
+                Layout.fillWidth: true
                 Layout.fillHeight: true
+
+                XChat.Conversation {
+                    id: conversation
+
+                    model: XChatConversationModel {
+                        id: conversationModel
+                    }
+
+                    function submit(input) {
+                        XChatRobot.SubmitMsgCall(input, '')
+                    }
+
+                    Connections {
+                        target: XChatRobot
+                        onXchatResponseSignal: {
+                            conversation.add(text, new Date(), false)
+                        }
+                    }
+
+                    visible: (activeTab == 'friends')
+
+                    // TODO: Temporary placeholder content
+                    Component.onCompleted: {
+                        var now = Date.now()
+
+                        conversation.add("Heading downtown?",
+                                         new Date(now - 180000), true)
+                        conversation.add("Absolutely, catching a show.",
+                                         new Date(now - 120000), false)
+                        conversation.add("We'll catch up later!",
+                                         new Date(now), true)
+                    }
+                }
+
+                XChat.Conversation {
+                    id: robot
+
+                    localTextColor: '#fff'
+                    localBackgroundColor: 'transparent'
+                    localBorderColor: 'transparent'
+                    remoteTextColor: Theme.primaryHighlight
+                    remoteBackgroundColor: 'transparent'
+                    remoteBorderColor: 'transparent'
+                    messageSpacing: 6
+                    timestampSpacing: 0
+                    simpleLayout: true
+
+                    model: XChatConversationModel {
+                        id: robotModel
+                    }
+
+                    Connections {
+                        target: wallet
+                        onConsoleResponse: {
+                            var text = response.error ? (response.error.message + ': '
+                                                         + response.error.code) : response.result
+
+                            if (typeof text === 'object') {
+                                text = JSON.stringify(text, null, 2)
+                            }
+
+                            robot.add(text)
+                        }
+                    }
+
+                    Component.onCompleted: {
+                        robot.add("XCITE ready", null, false)
+                    }
+
+                    function submit(input) {
+                        consoleCommandBuffer.unshift(input)
+                        consoleCommandBufferIdx = -1
+
+                        var args = input.split(' ').filter(function (x) {
+                            return x.length > 0
+                        })
+
+                        wallet.request("console", args[0], args.slice(1))
+                    }
+
+                    visible: (activeTab == 'robot')
+                }
             }
 
             // Bottom controls
@@ -85,8 +199,8 @@ Item {
                 id: xChatUserInput
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.leftMargin: 18.9
-                anchors.rightMargin: 18.9
+                anchors.leftMargin: viewMargin
+                anchors.rightMargin: viewMargin
                 height: 61
 
                 Rectangle {
@@ -111,6 +225,7 @@ Item {
 
                         img.source: "../icons/plus-button.svg"
                         img.sourceSize.width: 28
+                        img.sourceSize.height: 29
                     }
 
                     Rectangle {
@@ -143,6 +258,56 @@ Item {
                             color: "#ffffff"
 
                             Keys.onReturnPressed: onSubmitUserInput()
+                            Keys.onTabPressed: {
+                                // TODO: Poor man's tab completion, make better later
+                                var input = xChatTextInput.text
+                                var parts = input.split(' ')
+                                var matches = []
+
+                                for (var i = 0; i < consoleCommandCompletion.length; i++) {
+                                    var cmd = consoleCommandCompletion[i]
+
+                                    if (cmd.indexOf(parts[0]) === 0) {
+                                        matches.push(cmd)
+                                    }
+                                }
+
+                                if (matches.length === 1) {
+                                    xChatTextInput.text = input.replace(
+                                                parts[0], matches[0])
+                                } else if (matches.length > 1) {
+                                    robot.add('Commands:\n' + matches.join(
+                                                  '\n'))
+                                }
+                            }
+
+                            Keys.onUpPressed: {
+                                if (consoleCommandBuffer.length === 0) {
+                                    return
+                                }
+
+                                if (consoleCommandBufferIdx < consoleCommandBuffer.length - 1) {
+                                    consoleCommandBufferIdx++
+
+                                    xChatTextInput.text
+                                            = consoleCommandBuffer[consoleCommandBufferIdx]
+                                }
+                            }
+                            Keys.onDownPressed: {
+                                if (consoleCommandBuffer.length === 0) {
+                                    return
+                                }
+
+                                if (consoleCommandBufferIdx > 0) {
+                                    consoleCommandBufferIdx--
+
+                                    xChatTextInput.text
+                                            = consoleCommandBuffer[consoleCommandBufferIdx]
+                                } else {
+                                    consoleCommandBufferIdx = -1
+                                    xChatTextInput.text = ''
+                                }
+                            }
                         }
                     }
 

--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -71,6 +71,13 @@ ApplicationWindow {
         property string initialView: "xCite.home"
     }
 
+    Settings {
+        id: xChatSettings
+        category: "xchat"
+        property string sizeState: "minimal"
+        property string activeTab: "robot"
+    }
+
     Network {
         id: network
         handler: wallet
@@ -88,13 +95,15 @@ ApplicationWindow {
         xbyBalance = response
     }
 
-    function walletError(status) {
-        xcite.isNetworkActive = false
-        modalAlert({
-                       title: qsTr("NETWORK ERROR"),
-                       bodyText: qsTr(status),
-                       buttonText: qsTr("OK")
-                   })
+    function walletError(sender, status) {
+        //        xcite.isNetworkActive = false
+        if (sender === "ui") {
+            modalAlert({
+                           title: qsTr("NETWORK ERROR"),
+                           bodyText: qsTr(status),
+                           buttonText: qsTr("OK")
+                       })
+        }
     }
 
     function walletSuccess(result) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,8 +46,9 @@ int main(int argc, char *argv[])
     selector->setExtraSelectors(QStringList() << "mobile");
 #endif
 
-    XchatObject xchatobj;
-    xchatobj.Initialize();
+    XchatObject xchatRobot;
+    xchatRobot.Initialize();
+    engine.rootContext()->setContextProperty("XChatRobot", &xchatRobot);
 
     // wire-up testnet wallet
     Testnet wallet;
@@ -75,15 +76,11 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 #else
     // X-Chat
-    wallet.m_xchatobject = &xchatobj;
-    // connect QML signals to C++ slots
-    QObject::connect(engine.rootObjects().first(),SIGNAL(xchatSubmitMsgSignal(QString)),&xchatobj,SLOT(SubmitMsgCall(QString)));
-    // connect C++ signals to QML slots
-    QObject::connect(&xchatobj, SIGNAL(xchatResponseSignal(QVariant)),engine.rootObjects().first(), SLOT(xchatResponse(QVariant)));
+    wallet.m_xchatobject = &xchatRobot;
 
     // FauxWallet
     QObject::connect(&wallet, SIGNAL(response(QVariant)), engine.rootObjects().first(), SLOT(testnetResponse(QVariant)));
-    QObject::connect(&wallet, SIGNAL(walletError(QVariant)), engine.rootObjects().first(), SLOT(walletError(QVariant)));
+    QObject::connect(&wallet, SIGNAL(walletError(QVariant, QVariant)), engine.rootObjects().first(), SLOT(walletError(QVariant, QVariant)));
     QObject::connect(&wallet, SIGNAL(walletSuccess(QVariant)), engine.rootObjects().first(), SLOT(walletSuccess(QVariant)));
 #endif
 


### PR DESCRIPTION
- Robot and chat tabs of xchat now work independently 
- Refactor C++/QML bindings for X-Chat to work
- Wire up robot tab to send commands directly to the testnet wallet if available
- Add up/down command history and tab-completion of commands to the xchat input
- Xchat popup state now persisted on quit

Closes #209 