### PR TITLE
Add wrapper to QrCode to prevent layout jump when selecting address

### DIFF
--- a/frontend/XCITE/ReceiveCoins/Form.qml
+++ b/frontend/XCITE/ReceiveCoins/Form.qml
@@ -111,14 +111,18 @@ ColumnLayout {
         color: "#E3E3E3"
     }
 
-    QtQrCode {
+    Item {
+        width: 240
+        height: 240
         Layout.topMargin: 25
         Layout.bottomMargin: 25
         anchors.horizontalCenter: parent.horizontalCenter
-        data: formAddress.text
-        background: "transparent"
-        foreground: Theme.primaryHighlight
-        width: 240
-        height: 240
+
+        QtQrCode {
+            anchors.fill: parent
+            data: formAddress.text
+            background: "transparent"
+            foreground: Theme.primaryHighlight
+        }
     }
 }


### PR DESCRIPTION
We can't prevent the flicker as it's the delay caused by the testnet wallet looking up and returning the address information. This'll go away when we have zolt core wallet integration.

Fixes #197 