### PR TITLE
Fixup send/recv coin layouts to prevent jumping around

### DIFF
--- a/backend/addressbook/addressbookmodel.cpp
+++ b/backend/addressbook/addressbookmodel.cpp
@@ -32,9 +32,9 @@ int AddressBookModel::remove(int idx)
     Address *addr = items.at(idx);
     if (addr != NULL) {
         beginRemoveRows(QModelIndex(), idx, idx);
-        free(addr);
         items.remove(idx);
         endRemoveRows();
+        free(addr);
     }
 
     return (idx > 0 ? idx : 0);

--- a/frontend/Controls/AddressBook.qml
+++ b/frontend/Controls/AddressBook.qml
@@ -30,7 +30,6 @@ ListView {
         leftPadding: 20
         rightPadding: 20
         text: name || "Default"
-        font.family: "Roboto"
         font.weight: Font.Light
         font.pixelSize: 16
         color: addressBook.currentIndex == index ? "black" : "white"
@@ -71,7 +70,12 @@ ListView {
 
     function removeSelected() {
         if (currentItem) {
-            model.remove(currentIndex)
+            var idxToRemove = currentIndex
+
+            // Prevent highlight flicker
+            currentIndex--
+
+            model.remove(idxToRemove)
         }
     }
 }

--- a/frontend/Controls/TextInput.qml
+++ b/frontend/Controls/TextInput.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+
 import "../Theme" 1.0
 
 TextField {
@@ -19,6 +21,7 @@ TextField {
         radius: 4
         border.width: parent.activeFocus ? 2 : 0
         border.color: Theme.secondaryHighlight
+        implicitWidth: 273
     }
 
     onActiveFocusChanged: {

--- a/frontend/XCITE/ReceiveCoins/Form.qml
+++ b/frontend/XCITE/ReceiveCoins/Form.qml
@@ -18,9 +18,8 @@ ColumnLayout {
     }
 
     Controls.TextInput {
-        anchors.left: parent.left
-        anchors.right: parent.right
         id: formAddress
+        Layout.fillWidth: true
         readOnly: true
     }
 

--- a/frontend/XCITE/ReceiveCoins/ReceiveDiode.qml
+++ b/frontend/XCITE/ReceiveCoins/ReceiveDiode.qml
@@ -48,11 +48,13 @@ Controls.Diode {
 
                 Form {
                     id: form
-                    Layout.alignment: Qt.AlignTop
-                    Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.topMargin: diodeTopMargin
+                    Layout.fillWidth: true
                     Layout.minimumWidth: 273
+                    Layout.preferredWidth: 500
+
+                    Layout.alignment: Qt.AlignTop
+                    Layout.topMargin: diodeTopMargin
                     Layout.leftMargin: diodePadding
                     Layout.rightMargin: 10
                 }
@@ -75,10 +77,12 @@ Controls.Diode {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
                     Layout.minimumWidth: 197
+                    Layout.preferredWidth: 300
+
+                    Layout.alignment: Qt.AlignTop
                     Layout.topMargin: diodeTopMargin
                     Layout.bottomMargin: diodePadding
                     Layout.rightMargin: diodePadding
-                    Layout.alignment: Qt.AlignTop
                     Layout.maximumHeight: 504
                 }
             }

--- a/frontend/XCITE/SendCoins/Form.qml
+++ b/frontend/XCITE/SendCoins/Form.qml
@@ -19,8 +19,7 @@ ColumnLayout {
     Controls.TextInput {
         id: formAmount
 
-        anchors.left: parent.left
-        anchors.right: parent.right
+        Layout.fillWidth: true
         text: "0"
 
         validator: DoubleValidator {
@@ -63,8 +62,7 @@ ColumnLayout {
     Controls.TextInput {
         id: formAddress
 
-        anchors.left: parent.left
-        anchors.right: parent.right
+        Layout.fillWidth: true
         font.pixelSize: 24
 
         Connections {

--- a/frontend/XCITE/SendCoins/SendDiode.qml
+++ b/frontend/XCITE/SendCoins/SendDiode.qml
@@ -57,7 +57,6 @@ Controls.Diode {
             width: scrollView.width
 
             RowLayout {
-                Layout.fillWidth: true
                 Layout.fillHeight: true
 
                 Layout.alignment: Qt.AlignTop
@@ -65,11 +64,13 @@ Controls.Diode {
 
                 Form {
                     id: form
-                    Layout.alignment: Qt.AlignTop
-                    Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.topMargin: diodeTopMargin
+                    Layout.fillWidth: true
                     Layout.minimumWidth: 273
+                    Layout.preferredWidth: 500
+
+                    Layout.alignment: Qt.AlignTop
+                    Layout.topMargin: diodeTopMargin
                     Layout.leftMargin: diodePadding
                     Layout.rightMargin: 10
                 }
@@ -92,10 +93,12 @@ Controls.Diode {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
                     Layout.minimumWidth: 197
+                    Layout.preferredWidth: 300
+
+                    Layout.alignment: Qt.AlignTop
                     Layout.topMargin: diodeTopMargin
                     Layout.bottomMargin: diodePadding
                     Layout.rightMargin: diodePadding
-                    Layout.alignment: Qt.AlignTop
                     Layout.maximumHeight: 504
                 }
             }


### PR DESCRIPTION
- Receive and send coins layouts now grow/shrink the same way
- Removing items from the addressbook no longer cause the highlight to visibly jump around
- Changing selection in addressbook no longer causes the layout to jump around

Fixes #198 