### PR TITLE
Disable https until windows stops sucking at it

### DIFF
--- a/backend/integrations/MarketValue.cpp
+++ b/backend/integrations/MarketValue.cpp
@@ -3,7 +3,8 @@
 
 MarketValue::MarketValue(QObject *parent) : QObject(parent)
 {
-
+    // TODO: Temporary until we sort out SSL issues on windows and this can be reenabled
+    m_marketValue = "0.12";
 }
 
 void MarketValue::findXBYValue()

--- a/frontend/XCITE/Home/ChartDiode.qml
+++ b/frontend/XCITE/Home/ChartDiode.qml
@@ -11,7 +11,8 @@ Controls.Diode {
     ChartView {
         id: priceChartView
 
-        readonly property string updateUrl: "https://ticker.xtrabytes.global/data.json"
+        // TODO: Temporary until we sort out SSL issues on windows and https redirects can be reenabled on the domain
+        readonly property string updateUrl: "http://ticker.xtrabytes.global/data.json"
 
         anchors.fill: parent
         anchors.topMargin: diodeHeaderHeight

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
 
     // load market value
     MarketValue marketValue;
-    marketValue.findXBYValue();
+    // TODO: Temporary until we sort out SSL issues on windows and this can be reenabled
+    //marketValue.findXBYValue();
     engine.rootContext()->setContextProperty("marketValue", &marketValue);
 
     // set app version


### PR DESCRIPTION
After 5 hours of recompiling QT on Windows OpenSSL still doesn't want to work. 

I've made a call to disable HTTPS related stuff in XCITE (reverting to HTTP where possible) given the time remaining in this milestone.

@enervey Does this patch make things work again for you?
