### PR TITLE
Fix control font colors

### DIFF
--- a/frontend/Controls/ComboBox.qml
+++ b/frontend/Controls/ComboBox.qml
@@ -1,24 +1,30 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
-import QtQuick.Controls.Styles 1.4
 import Qt.labs.calendar 1.0
 
 ComboBox {
-    id: comboBoxId
-    style: ComboBoxStyle {
-        textColor: "#d5d5d5"
+    id: control
+    contentItem: Text {
+        text: control.displayText
+        color: control.pressed ? "white" : "#d5d5d5"
+        verticalAlignment: Text.AlignVCenter
+        font.weight: Font.Light
+        font.pixelSize: 16
+        leftPadding: 10
+        rightPadding: 10
+        elide: Text.ElideRight
     }
 
     onHoveredChanged: {
-        hovered ? comboBoxBackgroundId.state = "Hovering" : comboBoxBackgroundId.state = "Default"
+        hovered ? background.state = "Hovering" : background.state = "Default"
     }
 
     property string defaultBackgroundColor: "#2A2C31"
     property string hoveringBackgroundColor: "#46464b"
 
     background: Rectangle {
-        id: comboBoxBackgroundId
+        id: background
         radius: 6
         color: "#2A2C31"
         implicitHeight: 47
@@ -37,14 +43,14 @@ ComboBox {
             State {
                 name: "Hovering"
                 PropertyChanges {
-                    target: comboBoxBackgroundId
+                    target: background
                     color: hoveringBackgroundColor
                 }
             },
             State {
                 name: "Default"
                 PropertyChanges {
-                    target: comboBoxBackgroundId
+                    target: background
                     color: defaultBackgroundColor
                 }
             }

--- a/frontend/Controls/ComboBox.qml
+++ b/frontend/Controls/ComboBox.qml
@@ -1,10 +1,14 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
+import QtQuick.Controls.Styles 1.4
 import Qt.labs.calendar 1.0
 
 ComboBox {
     id: comboBoxId
+    style: ComboBoxStyle {
+        textColor: "#d5d5d5"
+    }
 
     onHoveredChanged: {
         hovered ? comboBoxBackgroundId.state = "Hovering" : comboBoxBackgroundId.state = "Default"

--- a/frontend/Controls/DatePicker.qml
+++ b/frontend/Controls/DatePicker.qml
@@ -19,6 +19,7 @@ TextField {
     rightPadding: 10
     topPadding: 0
     bottomPadding: 0
+    color: "#d5d5d5"
 
     state: "Default"
 

--- a/frontend/Controls/SearchBox.qml
+++ b/frontend/Controls/SearchBox.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.7
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.3
-import QtQuick.Controls.Styles 1.4
 import "../Controls" as Controls
 
 import "../Theme" 1.0

--- a/frontend/Controls/TextInputBlue.qml
+++ b/frontend/Controls/TextInputBlue.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
-import QtQuick.Controls.Styles 1.4
 
 Column {
     id: column
@@ -21,7 +20,9 @@ Column {
         placeholderText: placeholder
         anchors.horizontalCenter: parent.horizontalCenter
         color: "#10B9C5"
-        background: Rectangle { color: "transparent" }
+        background: Rectangle {
+            color: "transparent"
+        }
     }
 
     Rectangle {
@@ -31,5 +32,3 @@ Column {
         anchors.horizontalCenter: parent.horizontalCenter
     }
 }
-
-

--- a/frontend/XCITE/History/FilterTransactionsDiode.qml
+++ b/frontend/XCITE/History/FilterTransactionsDiode.qml
@@ -73,6 +73,7 @@ Controls.Diode {
             topPadding: 20
             font.weight: Font.Light
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: qsTr("Transaction value")
         }
 

--- a/frontend/XCITE/History/FilterTransactionsDiode.qml
+++ b/frontend/XCITE/History/FilterTransactionsDiode.qml
@@ -20,6 +20,7 @@ Controls.Diode {
         Label {
             font.weight: Font.Light
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: qsTr("Type")
         }
 
@@ -33,6 +34,7 @@ Controls.Diode {
             bottomPadding: 5
             font.weight: Font.Light
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: qsTr("Dates between")
         }
 
@@ -45,6 +47,7 @@ Controls.Diode {
             bottomPadding: 5
             font.weight: Font.Light
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: qsTr("and")
         }
 
@@ -56,6 +59,7 @@ Controls.Diode {
             topPadding: 15
             font.weight: Font.Light
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: qsTr("To")
         }
 

--- a/frontend/XCITE/Nodes/RegistrationConfirmation.qml
+++ b/frontend/XCITE/Nodes/RegistrationConfirmation.qml
@@ -54,10 +54,12 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 15
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Static registration string"
         }
         TextArea {
             id: regString
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -99,10 +101,12 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 20
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Deposit Transaction ID"
         }
         TextArea {
             id: depID
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -144,10 +148,12 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 20
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Fee Transaction ID"
         }
         TextArea {
             id: feeTrans
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -189,10 +195,12 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 20
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Public Static Key"
         }
         TextArea {
             id: pubKey
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -234,10 +242,12 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 20
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Placeholder"
         }
         TextArea {
             id: holderKey
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -283,6 +293,7 @@ Controls.Diode {
             Label {
                 anchors.left: parent.right
                 anchors.leftMargin: 10
+                color: "#d5d5d5"
                 text: "I have copied and saved all strings above to multiple secure locations that only I have access to"
             }
         }

--- a/frontend/XCITE/Nodes/RegistrationDetails.qml
+++ b/frontend/XCITE/Nodes/RegistrationDetails.qml
@@ -55,6 +55,7 @@ Controls.Diode {
             Layout.leftMargin: 25
             Layout.topMargin: 30
             font.pixelSize: 16
+            color: "#d5d5d5"
             text: "Static registration string"
         }
         Label {
@@ -68,6 +69,7 @@ Controls.Diode {
 
         TextArea {
             id: regString
+            color: "#d5d5d5"
             text: "   aFEFR452ffaf778wyJc5i8upNm5Vv8HMkwXqBR3kaf3452CxS"
             width: contentWidth + 20
 
@@ -109,12 +111,13 @@ Controls.Diode {
             font.pixelSize: 16
             Layout.leftMargin: 25
             Layout.topMargin: 20
+            color: "#d5d5d5"
             text: "XBY Deposit Address"
         }
         TextArea {
             id: addString
+            color: "#d5d5d5"
             text: "   BMy2BpwyJc5i8upNm5Vv8HMkwXqBR3kCxS"
-
             width: contentWidth + 20
             Layout.leftMargin: 25
             Layout.topMargin: 10
@@ -131,6 +134,7 @@ Controls.Diode {
             font.pixelSize: 16
             Layout.leftMargin: 25
             Layout.topMargin: 20
+            color: "#d5d5d5"
             text: "Accept transaction fee"
             visible: xcite.width > 1100
         }
@@ -149,11 +153,13 @@ Controls.Diode {
             Label {
                 anchors.right: parent.left
                 anchors.rightMargin: 10
+                color: "#d5d5d5"
                 text: "No"
             }
             Label {
                 anchors.left: parent.right
                 anchors.leftMargin: 10
+                color: "#d5d5d5"
                 text: "Yes"
             }
         }
@@ -162,12 +168,14 @@ Controls.Diode {
             font.pixelSize: 16
             Layout.leftMargin: 25
             Layout.topMargin: 20
+            color: "#d5d5d5"
             text: "Total Deposit"
         }
         Label {
             font.pixelSize: 14
             Layout.leftMargin: 25
             Layout.topMargin: 10
+            color: "#d5d5d5"
             text: "XBY "
         }
         Controls.ButtonModal {

--- a/frontend/XCITE/Nodes/RegistrationLevel.qml
+++ b/frontend/XCITE/Nodes/RegistrationLevel.qml
@@ -123,6 +123,7 @@ Controls.Diode {
                 font.weight: Font.Light
                 font.pixelSize: 16
                 bottomPadding: 5
+                color: "#d5d5d5"
                 text: {
                     if (level1 == 3)
                         qsTr("      Earnings:                    Low")
@@ -146,6 +147,7 @@ Controls.Diode {
                 font.weight: Font.Light
                 font.pixelSize: 16
                 bottomPadding: 5
+                color: "#d5d5d5"
                 text: {
                     if (level1 == 3)
                         qsTr("      Network Stake:            Low")
@@ -169,6 +171,7 @@ Controls.Diode {
                 font.weight: Font.Light
                 font.pixelSize: 16
                 bottomPadding: 15
+                color: "#d5d5d5"
                 text: {
                     if (level1 == 3)
                         qsTr("      Transfer Rate:              Low")
@@ -199,6 +202,7 @@ Controls.Diode {
                 font.weight: Font.Light
                 font.pixelSize: 16
                 topPadding: 14
+                color: "#d5d5d5"
                 text: "Payment"
             }
             Label {

--- a/frontend/XCITE/SendCoins/Form.qml
+++ b/frontend/XCITE/SendCoins/Form.qml
@@ -56,6 +56,7 @@ ColumnLayout {
     Label {
         font.pixelSize: 12
         bottomPadding: 10
+        color: "#d5d5d5"
         text: qsTr("Enter a XTRABYTES address in here.\nEx: BMy2BpwyJc5i7upNm5Vv8HMkwXqBR3kCxS ")
     }
 
@@ -80,7 +81,7 @@ ColumnLayout {
         rightPadding: 20
         font.pixelSize: 12
         text: qsTr("Or add a recipient from your address book")
-
+        color: "#d5d5d5"
         visible: xcite.width > 1100
         Image {
             fillMode: Image.PreserveAspectFit
@@ -110,12 +111,14 @@ ColumnLayout {
             text: Number(totalAmount).toFixed(2)
             font.weight: Font.Light
             font.pixelSize: 36
+            color: "#d5d5d5"
         }
     }
 
     Label {
         topPadding: 10
         font.pixelSize: 12
+        color: "#d5d5d5"
         text: qsTr("Transaction fee:") + " " + networkFee + " " + qsTr("XBY")
     }
 }

--- a/frontend/tools/Layout.qml
+++ b/frontend/tools/Layout.qml
@@ -49,24 +49,30 @@ ColumnLayout {
                 ColumnLayout {
                     Layout.margins: 15
                     Label {
+                        color: "#d5d5d5"
                         text: qsTr("XBY Transfer Amount (e.g. 1 or 1000):")
                     }
                     TextField {
                         id: transferAmount
+                        color: "#d5d5d5"
                         text: "1"
                     }
                     Label {
+                        color: "#d5d5d5"
                         text: qsTr("XBY Transfer Cycles (e.g. 5000):")
                     }
                     TextField {
                         id: transferCycles
+                        color: "#d5d5d5"
                         text: "5000"
                     }
                     Label {
+                        color: "#d5d5d5"
                         text: qsTr("Transactions Per Minute (Use a number between 1 and 1000 to prevent your system from freezing)")
                     }
                     TextField {
                         id: transactionsPerMin
+                        color: "#d5d5d5"
                         text: "500"
                     }
                     Label {


### PR DESCRIPTION
This fixes the unexpected control font color issues only present in static binaries.

The issue remains for the `TextInputBlue` (used in the Login forms) and `SearchBox` controls since there doesn't appear to be a way to override placeholder colors in Qt Controls 2 (they removed control styles). Maybe someone else can figure out a way to accomplish that. At any rate, the rest of this should get merged in very soon.

Fixes #228 