### PR TITLE
Add basic onboarding

### DIFF
--- a/frontend/DashboardForm.qml
+++ b/frontend/DashboardForm.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Layouts 1.3
 import "Controls" as Controls
+import "Onboarding" as Onboarding
 import "XCITE" as XCITE
 import "X-Change" as XChange
 import "X-Chat" as XChat

--- a/frontend/Onboarding/Introduction.qml
+++ b/frontend/Onboarding/Introduction.qml
@@ -5,11 +5,10 @@ import "../Controls" as Controls
 
 Column {
     id: onboardingIntroduction
-    readonly property color cDiodeBackground: "#2B2C31"
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter
     height: 500
-    spacing: 40
+    spacing: 30
 
     Image {
         smooth: true
@@ -32,11 +31,13 @@ Column {
     Label {
         font.pixelSize: 20
         color: "white"
-        width: 780
+        width: 540
         wrapMode: Text.WordWrap
         anchors.bottomMargin: 40
         anchors.horizontalCenter: parent.horizontalCenter
-        text: qsTr("This pre-release version of XCITE includes temporary builds of our XCITE, X-CHAT and X-CHANGE modules.")
+        horizontalAlignment: Text.AlignHCenter
+        lineHeight: 1.3
+        text: qsTr("This pre-release version of XCITE showcases development builds of our XCITE, X-CHAT and X-CHANGE modules.")
     }
 
     Controls.ButtonModal {
@@ -46,7 +47,7 @@ Column {
         labelText: "LET'S DO THIS"
         anchors.horizontalCenter: parent.horizontalCenter
         isPrimary: true
-        visible: settings.onboardingCompleted == false
+        visible: settings.onboardingCompleted === false
         onButtonClicked: {
             settings.onboardingCompleted = true
             mainRoot.push("../DashboardForm.qml")
@@ -55,7 +56,7 @@ Column {
 
     Timer {
         interval: 1000
-        running: Component.Ready && settings.onboardingCompleted == true
+        running: Component.Ready && settings.onboardingCompleted === true
         repeat: false
         onTriggered: {
             mainRoot.pushEnter = fadeInTransition

--- a/frontend/Onboarding/Introduction.qml
+++ b/frontend/Onboarding/Introduction.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import "../Controls" as Controls
+
+Column {
+    id: onboardingIntroduction
+    readonly property color cDiodeBackground: "#2B2C31"
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    height: 500
+    spacing: 40
+
+    Image {
+        smooth: true
+        anchors.horizontalCenter: parent.horizontalCenter
+        fillMode: Image.PreserveAspectFit
+        height: 250
+        source: "../backgrounds/launchscreen-logo.png"
+    }
+
+    Label {
+        id: versionLabel
+        font.pixelSize: 24
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 30
+        anchors.bottomMargin: 30
+        color: "white"
+        text: qsTr("XCITE - Version " + AppVersion)
+    }
+
+    Label {
+        font.pixelSize: 20
+        color: "white"
+        width: 780
+        wrapMode: Text.WordWrap
+        anchors.bottomMargin: 40
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: qsTr("This pre-release version of XCITE includes temporary builds of our XCITE, X-CHAT and X-CHANGE modules.")
+    }
+
+    Controls.ButtonModal {
+        Layout.fillWidth: false
+        width: 220
+        buttonHeight: 38
+        labelText: "LET'S DO THIS"
+        anchors.horizontalCenter: parent.horizontalCenter
+        isPrimary: true
+        onButtonClicked: {
+            mainRoot.push("../DashboardForm.qml")
+        }
+    }
+}

--- a/frontend/Onboarding/Introduction.qml
+++ b/frontend/Onboarding/Introduction.qml
@@ -46,8 +46,41 @@ Column {
         labelText: "LET'S DO THIS"
         anchors.horizontalCenter: parent.horizontalCenter
         isPrimary: true
+        visible: settings.onboardingCompleted == false
         onButtonClicked: {
+            settings.onboardingCompleted = true
             mainRoot.push("../DashboardForm.qml")
+        }
+    }
+
+    Timer {
+        interval: 1000
+        running: Component.Ready && settings.onboardingCompleted == true
+        repeat: false
+        onTriggered: {
+            mainRoot.pushEnter = fadeInTransition
+            mainRoot.pushExit = fadeOutTransition
+            mainRoot.push("../DashboardForm.qml")
+        }
+    }
+
+    Transition {
+        id: fadeInTransition
+        PropertyAnimation {
+            property: "opacity"
+            from: 0
+            to: 1
+            duration: 200
+        }
+    }
+
+    Transition {
+        id: fadeOutTransition
+        PropertyAnimation {
+            property: "opacity"
+            from: 1
+            to: 0
+            duration: 200
         }
     }
 }

--- a/frontend/Onboarding/Introduction.qml
+++ b/frontend/Onboarding/Introduction.qml
@@ -7,8 +7,10 @@ Column {
     id: onboardingIntroduction
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter
+    anchors.top: parent.top
+    anchors.topMargin: 15
     height: 500
-    spacing: 30
+    spacing: 20
 
     Image {
         smooth: true
@@ -22,8 +24,6 @@ Column {
         id: versionLabel
         font.pixelSize: 24
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 30
-        anchors.bottomMargin: 30
         color: "white"
         text: qsTr("XCITE - Version " + AppVersion)
     }
@@ -33,10 +33,9 @@ Column {
         color: "white"
         width: 540
         wrapMode: Text.WordWrap
-        anchors.bottomMargin: 40
         anchors.horizontalCenter: parent.horizontalCenter
         horizontalAlignment: Text.AlignHCenter
-        lineHeight: 1.3
+        lineHeight: 1.25
         text: qsTr("This pre-release version of XCITE showcases development builds of our XCITE, X-CHAT and X-CHANGE modules.")
     }
 

--- a/frontend/Settings/DeveloperSettings.qml
+++ b/frontend/Settings/DeveloperSettings.qml
@@ -34,6 +34,13 @@ ColumnLayout {
     }
 
     CheckBox {
+        id: skipOnboardingCheckbox
+        text: "Skip onboarding screens on startup"
+        checked: developerSettings.skipOnboarding
+        onClicked: developerSettings.skipOnboarding = this.checked
+    }
+
+    CheckBox {
         id: skipLoginCheckbox
         text: "Skip login screens on startup"
         checked: developerSettings.skipLogin

--- a/frontend/frontend.qrc
+++ b/frontend/frontend.qrc
@@ -125,5 +125,6 @@
         <file>X-Change/OrderBooks/OrderBooksDiode.qml</file>
         <file>X-Change/MarketTrades/MarketTradesDiode.qml</file>
         <file>Controls/SideMenuButtonSmall.qml</file>
+        <file>Onboarding/Introduction.qml</file>
     </qresource>
 </RCC>

--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -32,8 +32,7 @@ ApplicationWindow {
         pushExit: null
 
         Component.onCompleted: {
-            //this.push(developerSettings.skipLogin ? dashboardForm : loginForm)
-            this.push(onboarding)
+            this.push(developerSettings.skipOnboarding ? dashboardForm : onboarding)
         }
     }
 
@@ -70,11 +69,13 @@ ApplicationWindow {
         property alias width: xcite.width
         property alias height: xcite.height
         property string locale: "en_us"
+        property bool onboardingCompleted: false
     }
 
     Settings {
         id: developerSettings
         category: "developer"
+        property bool skipOnboarding: false
         property bool skipLogin: false
         property string initialView: "xCite.home"
     }

--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -6,6 +6,7 @@ import Qt.labs.settings 1.0
 
 import xtrabytes.xcite.xchat 1.0
 import Clipboard 1.0
+import "Onboarding" as Onboarding
 import "Login" as LoginComponents
 import "Theme" 1.0
 
@@ -31,13 +32,20 @@ ApplicationWindow {
         pushExit: null
 
         Component.onCompleted: {
-            this.push(developerSettings.skipLogin ? dashboardForm : loginForm)
+            //this.push(developerSettings.skipLogin ? dashboardForm : loginForm)
+            this.push(onboarding)
         }
     }
 
     Component {
         id: dashboardForm
         DashboardForm {
+        }
+    }
+
+    Component {
+        id: onboarding
+        Onboarding.Introduction {
         }
     }
 


### PR DESCRIPTION
- Add onboarding view
- Hide login views (they will be re-displayed later when authorization is functional)
- Display onboarding on load if necessary
- If user has already completed onboarding, display splash for 1 second, then fade into next view
- Add developer settings checkbox to skip onboarding

Closes #240 
Fixes #237
Fixes #235