### PR TITLE
Prevent chart events behind xchat popup

### DIFF
--- a/frontend/XchatPopup.qml
+++ b/frontend/XchatPopup.qml
@@ -26,6 +26,12 @@ Item {
     smooth: true
     z: 100
 
+    MouseArea {
+        propagateComposedEvents: false
+        anchors.fill: parent
+        hoverEnabled: true
+    }
+
     Connections {
         target: header
         onTabChanged: {


### PR DESCRIPTION
Fixes #249 

Note that the price scraper was offline so the chart is a bit banjoed at the moment, this'll correct itself over time