### PR TITLE
Dynamic windows builds no longer suck at SSL

### DIFF
--- a/backend/integrations/MarketValue.cpp
+++ b/backend/integrations/MarketValue.cpp
@@ -3,8 +3,6 @@
 
 MarketValue::MarketValue(QObject *parent) : QObject(parent)
 {
-    // TODO: Temporary until we sort out SSL issues on windows and this can be reenabled
-    m_marketValue = "0.12";
 }
 
 void MarketValue::findXBYValue()

--- a/frontend/XCITE/Home/ChartDiode.qml
+++ b/frontend/XCITE/Home/ChartDiode.qml
@@ -11,8 +11,7 @@ Controls.Diode {
     ChartView {
         id: priceChartView
 
-        // TODO: Temporary until we sort out SSL issues on windows and https redirects can be reenabled on the domain
-        readonly property string updateUrl: "http://ticker.xtrabytes.global/data.json"
+        readonly property string updateUrl: "https://ticker.xtrabytes.global/data.json"
 
         anchors.fill: parent
         anchors.topMargin: diodeHeaderHeight

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -57,8 +57,7 @@ int main(int argc, char *argv[])
 
     // load market value
     MarketValue marketValue;
-    // TODO: Temporary until we sort out SSL issues on windows and this can be reenabled
-    //marketValue.findXBYValue();
+    marketValue.findXBYValue();
     engine.rootContext()->setContextProperty("marketValue", &marketValue);
 
     // set app version


### PR DESCRIPTION
Need to download OpenSSL for windows and build it under MSYS or similar.

Once built, copy the following files to `build/release|debug:`
- ssleay32.dll
- libeay32.dll

These same files should be copied into the root of the dynamic build for distribution. I have the above built if someone wants a zip of the DLLs

