### PR TITLE
Set the default window size to a larger size if available

### DIFF
--- a/frontend/main.qml
+++ b/frontend/main.qml
@@ -32,8 +32,8 @@ ApplicationWindow {
         pushExit: null
 
         Component.onCompleted: {
-            var idealHeight = 800
-            var idealWidth = 1000
+            var idealHeight = (screen.height * 0.7) > 800 ? (screen.height * 0.7) : 800
+            var idealWidth = (screen.width * 0.7) > 1000 ? (screen.width * 0.7) : 1000
 
             var h = Math.min(screen.height - 100, idealHeight)
             var w = Math.min(screen.width - 100, idealWidth)


### PR DESCRIPTION
When calculating the default (ideal) window size, proportionally set the size according to the available screen size. Ideally this would be tested on a variety of resolutions before being merged.

Before:
![image](https://user-images.githubusercontent.com/17502298/38869526-fe767b8e-4218-11e8-8c47-64fa433ce061.png)

After:
![image](https://user-images.githubusercontent.com/17502298/38873678-573d9846-4224-11e8-8edf-a869f74c0c88.png)

Fixes #289