### PR TITLE
Fix build warnings

### DIFF
--- a/backend/xchat/xchataiml.cpp
+++ b/backend/xchat/xchataiml.cpp
@@ -475,14 +475,16 @@ QString XchatAIML::resolveNode(QDomNode* node, const QStringList &capturedTexts,
                 result = index < inputList.count() ? inputList[index] : QString("");
             }
             //the following just to avoid warnings !
-            else if (nodeName == "li")
-                ;
+            else if (nodeName == "li") {
+
+            }
         }
         //the following just to avoid warnings !
         else if ((nodeName == "template") || (nodeName == "pattern") || (nodeName == "li")
                  || (nodeName == "person") || (nodeName == "person2") || (nodeName == "gender")
-                 || (nodeName == "parsedCondition"))
-            ;
+                 || (nodeName == "parsedCondition")) {
+
+        }
     }
     return result;
 }


### PR DESCRIPTION
- Minor syntax change to 2 empty `if` statements to prevent build warnings

Fixes the following warnings:

![image](https://user-images.githubusercontent.com/17502298/38956756-912d9a26-4326-11e8-8952-3a0620d7de88.png)
